### PR TITLE
cleanup-io-connectors-step1

### DIFF
--- a/modules/ROOT/pages/io-connectors.adoc
+++ b/modules/ROOT/pages/io-connectors.adoc
@@ -2,22 +2,41 @@
 
 When you have Luna Streaming xref:quickstart-server-installs[installed] and running, add IO connectors to connect your deployment to external systems like https://cassandra.apache.org/_/index.html[Apache Cassandra], https://www.elastic.co/[ElasticSearch], and more. +
 
-* *Source connectors:* Source connectors pull messages from external topics and persist the messages to Apache Pulsar™ topics. For more, see https://pulsar.apache.org/docs/en/io-connectors/#source-connector[Pulsar built-in connectors^]. +
+* *Source connectors:* Source connectors read messages from external topics and persist the messages to Apache Pulsar™ topics. For more, see https://pulsar.apache.org/docs/en/io-connectors/#source-connector[Pulsar built-in connectors^]. +
 
-* *Sink connectors:* Sink connectors pull messages from Pulsar topics and persist the messages to external systems. For more, see https://pulsar.apache.org/docs/en/io-connectors/#sink-connector[Pulsar built-in connectors^]. +
+* *Sink connectors:* Sink connectors read messages from Pulsar topics and persist the messages to external systems. For more, see https://pulsar.apache.org/docs/en/io-connectors/#sink-connector[Pulsar built-in connectors^]. +
 
 This doc lists the connectors supported by *Luna Streaming*. 
 
 == Sink Connectors
 
-*Sink connectors* pull messages from Pulsar topics and persist the messages to external systems. +
+*Sink connectors* read messages from Pulsar topics and persist the messages to external systems. +
 
 The following sink connectors are included in the `<luna-streaming-all>` deployment and are supported by DataStax Luna Streaming. +
 
 [#datastax-pulsar-sink]
-=== DataStax pulsar-sink
+=== DataStax enhanced Cassandra sink connector
 
-To configure, deploy, and use the DataStax Pulsar sink connector, see the https://docs.datastax.com/en/pulsar-connector/1.4/index.html[DataStax Pulsar connector documentation^].
+To configure, deploy, and use the DataStax enhanced Cassandra sink connector, see the https://docs.datastax.com/en/pulsar-connector/1.4/index.html[DataStax Pulsar connector documentation^]. +
+
+The DataStax enhanced Cassandra sink connector offers the following advantages over the OSS Pulsar Cassandra sink connector: +
+
+* Flexibility in mapping Apache Pulsar™ messages to DSE and Cassandra tables. +
+
+* Enterprise grade security support including built-in SSL, and LDAP integration. +
+
+* Consumes all Apache Pulsar™ primitives including primitives, JSON and Avro formats. +
+
+* Flexible time/date formatting. +
+
+* Configurable consistency level. +
+
+* Row-level Time-to-Live (TTL). +
+
+* Distributed mode, high availability (HA) support. +
+
+* Standalone mode support for development. +
+
 [#elasticsearch-sink]
 === ElasticSearch sink
 
@@ -50,7 +69,7 @@ To configure, deploy, and use the Kinesis sink connector, see the https://pulsar
 
 == Source Connectors
 
-*Source connectors* pull messages from external topics and persist the messages to Pulsar topics. +
+*Source connectors* read messages from external topics and persist the messages to Pulsar topics. +
 
 The following sink connectors are included in the `<luna-streaming-all>` deployment and are supported by DataStax Luna Streaming. +
 

--- a/modules/ROOT/pages/io-connectors.adoc
+++ b/modules/ROOT/pages/io-connectors.adoc
@@ -2,6 +2,10 @@
 
 When you have Luna Streaming xref:quickstart-server-installs[installed] and running, add IO connectors to connect your deployment to external systems like https://cassandra.apache.org/_/index.html[Apache Cassandra], https://www.elastic.co/[ElasticSearch], and more. +
 
+* *Source connectors:* Source connectors pull messages from external topics and persist the messages to Apache Pulsar™ topics. For more, see https://pulsar.apache.org/docs/en/io-connectors/#source-connector[Pulsar built-in connectors^]. +
+
+* *Sink connectors:* Sink connectors pull messages from Pulsar topics and persist the messages to external systems. For more, see https://pulsar.apache.org/docs/en/io-connectors/#sink-connector[Pulsar built-in connectors^]. +
+
 This doc lists the connectors supported by *Luna Streaming*. 
 
 == Sink Connectors

--- a/modules/ROOT/pages/io-connectors.adoc
+++ b/modules/ROOT/pages/io-connectors.adoc
@@ -1,136 +1,83 @@
 = Luna Streaming IO connectors
 
-When you have Luna Streaming installed and running, add IO connectors to your deployment to interact with external systems, such as Apache Cassandra®, Elasticsearch, and others.
+When you have Luna Streaming xref:quickstart-server-installs[installed] and running, add IO connectors to connect your deployment to external systems like https://cassandra.apache.org/_/index.html[Apache Cassandra], https://www.elastic.co/[ElasticSearch], and more. +
 
-* *Source connectors:* Source connectors pull messages from external topics and persist the messages to Apache Pulsar™ topics. For more, see https://pulsar.apache.org/docs/en/io-connectors/#source-connector[Pulsar built-in connectors^].
+This doc lists the connectors supported by *Luna Streaming*. 
 
-* *Sink connectors:* Sink connectors pull messages from Pulsar topics and persist the messages to external systems. For more, see https://pulsar.apache.org/docs/en/io-connectors/#sink-connector[Pulsar built-in connectors^].
-== Processing guarantees
+== Sink Connectors
 
-Processing guarantees handle errors when writing messages to Pulsar topics:
+*Sink connectors* pull messages from Pulsar topics and persist the messages to external systems. +
 
-* *ATLEAST_ONCE*: Each message sent to the source can be processed more than once.
-* *ATMOST_ONCE*: The message sent to the source is processed at most once. Therefore, there is a chance that the message is not processed.
-* *EFFECTIVELY_ONCE*: Each message sent to the source will have one output associated with it.
+The following sink connectors are included in the `<luna-streaming-all>` deployment and are supported by DataStax Luna Streaming. +
 
-For more about processing guarantees, see https://pulsar.apache.org/docs/en/io-overview/#processing-guarantee[processing guarantees^].
+[#datastax-pulsar-sink]
+=== DataStax pulsar-sink
 
-== Adding third-party connectors
+To configure, deploy, and use the DataStax Pulsar sink connector, see the https://docs.datastax.com/en/pulsar-connector/1.4/index.html[DataStax Pulsar connector documentation^].
+[#elasticsearch-sink]
+=== ElasticSearch sink
 
-Datastax offers https://github.com/datastax/pulsar-3rdparty-connector[third-party connector support^] for creating Pulsar connectors on the base of existing Kafka connectors. This allows developers to quickly move connectors from their Apache Kafka infrastructure into Apache Pulsar.
+To configure, deploy, and use the ElasticSearch sink connector, see the https://pulsar.apache.org/docs/next/io-elasticsearch-sink/[Pulsar documentation^].
 
-=== Prerequisites
+[#jdbc-clickhouse-sink]
+=== JDBC-Clickhouse sink
 
-. https://www.oracle.com/java/technologies/downloads/[JDK 11+^] installed.
-. https://maven.apache.org/download.cgi?Preferred=ftp://ftp.osuosl.org/pub/apache/[Maven 3.8^] installed.
+To configure, deploy, and use the JDBC-Clickhouse sink connector, see the https://pulsar.apache.org/docs/next/io-jdbc-sink/[Pulsar documentation^].
 
-=== Building connectors
+[#jdbc-mariadb-sink]
+=== JDBC-MariaDB sink
 
-. Clone the connector's repo. 
-. Run `mvn clean install` from the root.
-. Copy the connector's `.nar` file to the `connectors` directory in the Pulsar director.
-+
-[NOTE]
-====
-The connector's `.nar` files can be found at `pulsar-connectors/<connector_name>/target/pulsar-3rdparty-pulsar-connectors-<connector_name>-0.1.0-SNAPSHOT.nar`.
-====
+To configure, deploy, and use the JDBC-MariaDB sink connector, see the https://pulsar.apache.org/docs/next/io-jdbc-sink#example-for-mariadb[Pulsar documentation^].
 
-. Modify the connector's `config.yaml` file to match the connector YAML files below. 
-+
-This creates an adapter for the connector. 
+[#jdbc-postgres-sink]
+=== JDBC-PostgreSQL sink
 
-For more, see https://pulsar.apache.org/docs/en/standalone/#install-builtin-connectors-optional[Install built-in connectors^].
+To configure, deploy, and use the JDBC-PostgreSQL connector, see the https://pulsar.apache.org/docs/next/io-jdbc-sink#example-for-postgresql[Pulsar documentation^].
 
-=== Sink connector `config.yaml` example
+[#kafka-sink]
+=== Kafka sink
 
-[source, shell]
-----
-# Pulsar KCA Sink expects "processingGuarantees" to be "EFFECTIVELY_ONCE"`
-processingGuarantees: "EFFECTIVELY_ONCE"
-configs:
-  # Size of messages in bytes the sink will attempt to batch messages together before flush.
-  # batchSize: 16384
-  # Time interval in milliseconds the sink will attempt to batch messages together before flush.
-  # lingerTimeMs: 2147483647
-  # In case of Record<KeyValue<>> data use key from KeyValue<> instead of one from Record.
-  # unwrapKeyValueIfAvailable: "true"
-  # The Kafka topic name that passed to Kafka sink.
-  topic: "my-topic"
-  # Pulsar topic to store offsets at.
-  offsetStorageTopic: "kafka-connect-sink-offsets"
-  # A Kafka connector sink class to use.
-  kafkaConnectorSinkClass: "com.third.party.CoolSinkConnector"
-  # Config properties to pass to the Kafka connector.
-  kafkaConnectorConfigProperties:
-    # The following properties passed directly to Kafka Connect Sink and defined by it or by
-    # https://github.com/apache/kafka/blob/2.7/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
-    name: "test-sink"
-    connector.class: "com.third.party.CoolSinkConnector"
-    tasks.max: "1"
-    topics: "my-topic"
-    ...
-----
+To configure, deploy, and use the Kafka sink connector, see the https://pulsar.apache.org/docs/next/io-kafka-sink#configuration[Pulsar documentation^].
 
-=== Source connector `config.yaml` example
+[#kinesis-sink]
+=== Kinesis sink
 
-[source, shell]
-----
-tenant: "public"
-namespace: "default"
-name: "test-source"
-topicName: "test-topic"
-parallelism: 1
-# A Kafka connector source class to use.
-className: "com.third.party.CoolSourceConnector"
-configs:
-  # Present the message only consist of payload.
-  # json-with-envelope: "false"
+To configure, deploy, and use the Kinesis sink connector, see the https://pulsar.apache.org/docs/next/io-kinesis-sink#configuration[Pulsar documentation^].
 
-  # Pulsar topic to store Kafka connector offsets at
-  offset.storage.topic: "kafka-connect-source-offsets"
-  # Pulsar namespace to store the output topics
-  topic.namespace: "public/default"
-  
-  # Config properties to pass to the Kafka connector.
-  # The following properties passed directly to Kafka Connect Sink and defined by it or by
-  # https://github.com/apache/kafka/blob/2.7/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+== Source Connectors
 
-  # A Kafka connector source class to use.
-  task.class: "com.third.party.CoolSourceConnector"
-  # The converter provided by Kafka Connect to convert record value.
-  value.converter: "org.apache.kafka.connect.json.JsonConverter"
-  # The converter provided by Kafka Connect to convert record key.
-  key.converter: "org.apache.kafka.connect.json.JsonConverter"
-  ...
-----
+*Source connectors* pull messages from external topics and persist the messages to Pulsar topics. +
 
-== Troubleshooting
+The following sink connectors are included in the `<luna-streaming-all>` deployment and are supported by DataStax Luna Streaming. +
 
-These are common solutions for problems encountered while using KCA to create a new connector:
+[#debezium-mongodb-source]
+=== Debezium MongoDB source
 
-. Ensure the connector's license allows its use and redistribution. For more, see the https://www.apache.org/legal/resolved.html[Apache third-party license policy^].
-. Resolve third-party dependencies if there is a Maven dependency conflict of transitive dependencies in build time or dependency conflict in runtime caused by third-party dependencies packaged with the connector. To resolve third-party dependencies, see xref:io-connectors.adoc#shading[Shading third-party connectors^].
+To configure, deploy, and use the Debezium MongoDB source connector, see the https://pulsar.apache.org/docs/next/io-debezium-source#mongodb-configuration[Pulsar documentation^].
 
-[#shading]
-=== Shading third-party connectors
+[#debezium-mysql-source]
+=== Debezium MySQL source
 
-If your connector includes third-party dependencies, you may need to rename some classes. This is called "shading."
+To configure, deploy, and use the Debezium MySQL source connector, see the https://pulsar.apache.org/docs/next/io-debezium-source#configuration-1[Pulsar documentation^].
 
-. Copy `shaded-dependencies/template-shaded/` to `shaded-dependencies/<connector_name>`. 
-. Add the new module into `shaded-dependencies/pom.xml`.
-. Ensure third-party dependencies are renamed as specified in `shaded-dependencies/<connector name>/pom.xml` 
-. Build with `mvn clean install`.
-. Copy `pulsar-connectors/template/` to `pulsar-connectors/<connector_name>/`.
-. Add the new module into `pulsar-connectors/pom.xml`.
-. Update the `pulsar-connectors/<connector name>/README.md`.
-. Build with `mvn clean install`. 
-. Run `mvn dependency:tree -verbose` to review how Maven auto-resolved potential dependency conflicts. Fix as needed.
+[#debezium-postgres-source]
+=== Debezium Postgres source
 
-For more information on shading and troubleshooting, see the https://github.com/datastax/pulsar-3rdparty-connector[Third-party connectors GitHub readme^].
+To configure, deploy, and use the Debezium PostgreSQL source connector, see the https://pulsar.apache.org/docs/next/io-debezium-source#configuration-2[Pulsar documentation^].
 
-=== Next
+[#kafka-source]
+=== Kafka source
 
-Learn more about Pulsar IO connectors https://pulsar.apache.org/docs/en/io-overview/[here^].
+To configure, deploy, and use the Kafka source connector, see the https://pulsar.apache.org/docs/next/io-kafka-source#configuration[Pulsar documentation^].
+
+[#kinesis-source]
+=== Kinesis source
+
+To configure, deploy, and use the Kinesis source connector, see the https://pulsar.apache.org/docs/next/io-kinesis-source#configuration[Pulsar documentation^].
+
+== What's next?
+
+For more on Pulsar IO connectors, see the https://pulsar.apache.org/docs/en/io-overview/[Pulsar documentation^].
 
 
 


### PR DESCRIPTION
Step 1: The general concept of Pulsar I/O connectors and built-in list of available connectors (can point to OSS Pulsar doc)
After we push this we continue to Step 2 for Enhanced connectors.
Coppi build: https://coppi.sjc.dsinternal.org/en/cleanup-io-connectors/streaming/2.8/io-connectors.html