### PR TITLE
fix-link

### DIFF
--- a/modules/components/pages/pulsar-monitor.adoc
+++ b/modules/components/pages/pulsar-monitor.adoc
@@ -84,7 +84,7 @@ NOTE: Kubernetes' pod and service, and individual broker monitoring are only sup
 
 == Docker
 
-Pulsar Heartbeat's official docker image can be pulled https://hub.docker.com/repository/docker/datastax/pulsar-heartbeat/tags?page=1&ordering=last_updated[here]
+Pulsar Heartbeat's official docker image can be pulled https://hub.docker.com/r/datastax/pulsar-heartbeat[here].
 
 === Docker compose
 


### PR DESCRIPTION
Suggestions: The docker link requires login. The URL should point to <a href="https://urldefense.com/v3/__https://hub.docker.com/r/datastax/pulsar-heartbeat__;!!PbtH5S7Ebw!bzRroNK17gAuHoBVxzgNm89WcVxlbSmaMS9IbA-sZ5YJzn3EAb_JpaAgLXXdcFhVjyO8D0cD2Z8$">https://hub.docker.com/r/datastax/pulsar-heartbeat</a>