### PR TITLE
docs: STREAM-694 helm chart link

### DIFF
--- a/modules/install-upgrade/pages/quickstart-helm-installs.adoc
+++ b/modules/install-upgrade/pages/quickstart-helm-installs.adoc
@@ -28,7 +28,10 @@ The resulting configuration includes support for:
 
 == Prerequisites
 
-For an example set of production cluster values, see the DataStax production-ready https://github.com/datastax/pulsar-helm-chart[Helm chart]. +
+[IMPORTANT]
+====
+The DataStax production-ready Helm chart is now deprecated. For new deployments, we recommend using the DataStax https://github.com/datastax/kaap/[KAAP operator Helm chart], which provides Kubernetes-native autoscaling and simplified management for Apache Pulsar clusters.
+====
 
 DataStax recommends these hardware resources for running Luna Streaming in a Kubernetes environment: +
 

--- a/modules/install-upgrade/pages/quickstart-helm-installs.adoc
+++ b/modules/install-upgrade/pages/quickstart-helm-installs.adoc
@@ -1,4 +1,4 @@
-= Quick Start for Helm Chart installs
+= Quick Start for Helm Chart installs (deprecated)
 :page-tag: luna-streaming,dev,admin,install,pulsar
 
 [IMPORTANT]

--- a/modules/install-upgrade/pages/quickstart-helm-installs.adoc
+++ b/modules/install-upgrade/pages/quickstart-helm-installs.adoc
@@ -1,6 +1,11 @@
 = Quick Start for Helm Chart installs
 :page-tag: luna-streaming,dev,admin,install,pulsar
 
+[IMPORTANT]
+====
+The DataStax production-ready Helm chart is now deprecated. For new deployments, we recommend using the DataStax https://github.com/datastax/kaap/[KAAP operator Helm chart], which provides Kubernetes-native autoscaling and simplified management for Apache Pulsar clusters. For more information, see the xref:kaap-operator::index.adoc[Kubernetes Autoscaling for Apache Pulsar (KAAP)] documentation.
+====
+
 You have options for installing *DataStax Luna Streaming*:
 
 * Via the provided *DataStax Helm chart* for an existing Kubernetes environment locally or with a cloud provider, as covered in this topic. +
@@ -27,11 +32,6 @@ The resulting configuration includes support for:
 * Ingress for all HTTP ports (Pulsar Admin Console, Prometheus, Grafana, others)
 
 == Prerequisites
-
-[IMPORTANT]
-====
-The DataStax production-ready Helm chart is now deprecated. For new deployments, we recommend using the DataStax https://github.com/datastax/kaap/[KAAP operator Helm chart], which provides Kubernetes-native autoscaling and simplified management for Apache Pulsar clusters.
-====
 
 DataStax recommends these hardware resources for running Luna Streaming in a Kubernetes environment: +
 


### PR DESCRIPTION
* Add a prominent deprecation notice for the DataStax production-ready Helm chart, recommending the KAAP operator Helm chart for new deployments, and included links to the KAAP operator documentation.
* Remove the reference to the production cluster values example from the deprecated DataStax Helm chart in the prerequisites section.