### PR TITLE
DOC-5598 Add a FAQ for CDC connector

### DIFF
--- a/modules/ROOT/pages/faqs.adoc
+++ b/modules/ROOT/pages/faqs.adoc
@@ -115,10 +115,11 @@ There are two packages:
 If you're using open-source software (OSS) Apache Pulsar, you can use DataStax Apache Pulsar Connector with the OSS to take advantage of this `pulsar-sink` for Cassandra.
 See the xref:pulsar-connector:ROOT:index.adoc[DataStax Apache Pulsar Connector documentation].
 
-== APIs
+== What is the {company} Change Data Capture (CDC) for Cassandra connector?
 
-=== What client APIs does DataStax Luna Streaming provide?
+This source connector streams data changes from Cassandra tables to Pulsar topics.
+For more information, see the xref:cdc-for-cassandra:ROOT:index.adoc[{company} CDC for Cassandra connector documentation].
+
+== What client APIs does DataStax Luna Streaming provide?
 
 The same as for Apache Pulsar. See https://pulsar.apache.org/docs/en/client-libraries/.
-
-


### PR DESCRIPTION
Only added to latest version.

Add FAQ to link to the DS CDC for C* connector docs from the Luna Streaming docs.
The Luna Streaming docs don't mention CDC anywhere else so I chose not to introduce a new topic.
https://d5rxiv0do0q3v.cloudfront.net/doc-5598/luna-streaming/3.1-3.x/faqs.html#what-is-the-datastax-change-data-capture-cdc-for-cassandra-connector